### PR TITLE
Fixed ModuleNotFound error for category_encoders

### DIFF
--- a/DEMO/Classification.ipynb
+++ b/DEMO/Classification.ipynb
@@ -62,6 +62,7 @@
    ],
    "source": [
     "!pip3 install GML"
+    "!pip3 install category_encoders"
    ]
   },
   {

--- a/DEMO/Regression.ipynb
+++ b/DEMO/Regression.ipynb
@@ -62,6 +62,7 @@
    ],
    "source": [
     "!pip3 install GML"
+    "!pip3 install category_encoders"
    ]
   },
   {


### PR DESCRIPTION
The "from GML.Ghalat_Machine_Learning import Ghalat_Machine_Learning" statement throws a "ModuleNotFoundError: No module named 'category_encoders'" error. The quick solution is to install category_encoders separately before executing the import statement.